### PR TITLE
correct userscript file extension .user.js

### DIFF
--- a/sc2-integrate.user.js
+++ b/sc2-integrate.user.js
@@ -2,8 +2,8 @@
 // @name SC2-integrate
 // @license MIT
 // @version 1.1
-// @downloadURL https://raw.githubusercontent.com/Marek71cz/sc2-integrate/master/sc2-integrate.js
-// @updateURL https://raw.githubusercontent.com/Marek71cz/sc2-integrate/master/sc2-integrate.js
+// @downloadURL https://raw.githubusercontent.com/Marek71cz/sc2-integrate/master/sc2-integrate.user.js
+// @updateURL https://raw.githubusercontent.com/Marek71cz/sc2-integrate/master/sc2-integrate.user.js
 // @description Integrace SC2 do CSFD, IMDB a TRAKT.TV.
 // @match https://www.csfd.cz/film/*
 // @match https://www.csfd.cz/podrobne-vyhledavani/*


### PR DESCRIPTION
Kdyz ma userscript spravnou koncovku user.js tak to uzivateli pri otevreni z https://raw.githubusercontent.com/ rovnou nabidne instalaci. Bez toho mi to ve FF s Tampermonkey nefungovalo - respektive musel jsem to instalovat rucne.
Pripadne muzes jeste udelat symlink `sc2-integrate.js -> sc2-integrate.user.js` aby si mohli v klidu updatnout ti co to instalovali rucne(pokud nemas linux/MAC muzu tam ten symlink jeste dodelat)